### PR TITLE
[U] Fix errors in TestLexer

### DIFF
--- a/RegulareBackend.iml
+++ b/RegulareBackend.iml
@@ -9,6 +9,15 @@
     </content>
     <orderEntry type="jdk" jdkName="17" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="junit" level="project" />
+    <orderEntry type="module-library" exported="">
+      <library name="JUnit4">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.13.1/junit-4.13.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/src/com/terraincognita/lexer/Lexer.java
+++ b/src/com/terraincognita/lexer/Lexer.java
@@ -2,7 +2,6 @@ package com.terraincognita.lexer;
 
 import com.terraincognita.errors.RegexSyntaxException;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;

--- a/src/com/terraincognita/lexer/Token.java
+++ b/src/com/terraincognita/lexer/Token.java
@@ -14,7 +14,7 @@ public class Token {
     protected static final HashSet<Character> OPS = new HashSet<Character>(Arrays.asList('|'));
     protected static final HashSet<Character> QUANTIFIERS = new HashSet<>(Arrays.asList('*', '+', '?'));
 
-    public Token(TokenType tokenType, char value) {
+    private Token(TokenType tokenType, char value) {
         this.tokenType = tokenType;
         this.value = value;
     }
@@ -49,4 +49,15 @@ public class Token {
     public char getValue() {
         return this.value;
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof Token t) {
+            if (t.getTokenType() == this.getTokenType() && t.getValue() == this.getValue())
+                return true;
+            return false;
+        }
+        return false;
+    }
+
 }

--- a/src/test/ParserDemo.java
+++ b/src/test/ParserDemo.java
@@ -8,7 +8,7 @@ import com.terraincognita.parser.ast.ASTNode;
 
 import java.util.Set;
 
-public class CompilerTest {
+public class ParserDemo {
     public static void main(String[] args) {
         Lexer lexer = new Lexer("(a|b)cd*");
         lexer.tokenize();

--- a/src/test/TestLexer.java
+++ b/src/test/TestLexer.java
@@ -1,12 +1,11 @@
-import com.terraincognita.lexer.*;
-
+import com.terraincognita.errors.RegexSyntaxException;
+import com.terraincognita.lexer.Lexer;
+import com.terraincognita.lexer.Token;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-
-import static org.junit.Assert.*;
 
 public class TestLexer {
 
@@ -17,15 +16,23 @@ public class TestLexer {
     }
 
     @Test
-    public void testUnmatchedDelim() {
+    public void testMatchedDelim() {
         String inputRegex = "(())";
         Lexer lexer = new Lexer(inputRegex);
+        lexer.tokenize();
         ArrayList<Token> expected = new ArrayList<Token>();
-        expected.add(new Token(TokenType.LeftDelimiter, '('));
-        expected.add(new Token(TokenType.LeftDelimiter, '('));
-        expected.add(new Token(TokenType.RightDelimiter, ')'));
-        expected.add(new Token(TokenType.RightDelimiter, ')'));
+        expected.add(Token.createToken('('));
+        expected.add(Token.createToken('('));
+        expected.add(Token.createToken(')'));
+        expected.add(Token.createToken(')'));
         assert lexer.getTokens().equals(expected);
+    }
+
+    @Test(expected = RegexSyntaxException.class)
+    public void testUnmatchedDelim() {
+        String inputRegex = "(()";
+        Lexer lexer = new Lexer(inputRegex);
+        lexer.tokenize();
     }
 
     @After


### PR DESCRIPTION
The test did not create instances of `Token`s properly using the `createToken` method. Additionally, Token does not have an overridden `equals` method so by default it would compare by reference. I added the `equals` method that checks the equality of two tokens by their value. I also included one additional test for the case when `Lexer` throws an error due to unmatched parentheses.